### PR TITLE
Added option to chose an encoder to encode the text instead of assuming UTF8

### DIFF
--- a/Sources/QR8bitByte.swift
+++ b/Sources/QR8bitByte.swift
@@ -29,9 +29,9 @@ struct QR8bitByte {
     let data: String
     let parsedData: Data
     
-    init?(_ data: String) {
+    init?(_ data: String, encodingMode: String.Encoding = .utf8) {
         self.data = data
-        guard let parsed = data.data(using: .utf8) else {
+        guard let parsed = data.data(using: encodingMode) else {
             return nil
         }
         self.parsedData = parsed

--- a/Sources/QR8bitByte.swift
+++ b/Sources/QR8bitByte.swift
@@ -29,9 +29,9 @@ struct QR8bitByte {
     let data: String
     let parsedData: Data
     
-    init?(_ data: String, encodingMode: String.Encoding = .utf8) {
+    init?(_ data: String, encoding: String.Encoding = .utf8) {
         self.data = data
-        guard let parsed = data.data(using: encodingMode) else {
+        guard let parsed = data.data(using: encoding) else {
             return nil
         }
         self.parsedData = parsed

--- a/Sources/QRCode.swift
+++ b/Sources/QRCode.swift
@@ -41,10 +41,11 @@ open class QRCode {
     ///
     /// - Warning: Is computationally intensive.
     public init?(_ text: String,
+                 encoding: String.Encoding = .utf8,
                  errorCorrectLevel: QRErrorCorrectLevel = .H,
                  withBorder hasBorder: Bool = true) {
         guard let typeNumber = try? QRCodeType.typeNumber(of: text, errorCorrectLevel: errorCorrectLevel)
-            , let model = QRCodeModel(text: text, typeNumber: typeNumber, errorCorrectLevel: errorCorrectLevel)
+            , let model = QRCodeModel(text: text, encoding: encoding, typeNumber: typeNumber, errorCorrectLevel: errorCorrectLevel)
             else { return nil }
         self.typeNumber = typeNumber
         self.model = model

--- a/Sources/QRCodeModel.swift
+++ b/Sources/QRCodeModel.swift
@@ -30,10 +30,12 @@ struct QRCodeModel {
     private let encodedText: QR8bitByte
     private var dataCache: [Int]
     
-    init?(text: String, typeNumber: Int, errorCorrectLevel: QRErrorCorrectLevel) {
-        guard let encoded = QR8bitByte(text) else {
+    init?(text: String, typeNumber: Int, errorCorrectLevel: QRErrorCorrectLevel, textEncoding: String.Encoding = .utf8) {
+        
+        guard let encoded = QR8bitByte(text, encodingMode: textEncoding) else {
             return nil
         }
+        
         self.encodedText = encoded
         self.typeNumber = typeNumber
         self.errorCorrectLevel = errorCorrectLevel

--- a/Sources/QRCodeModel.swift
+++ b/Sources/QRCodeModel.swift
@@ -30,9 +30,9 @@ struct QRCodeModel {
     private let encodedText: QR8bitByte
     private var dataCache: [Int]
     
-    init?(text: String, textEncoding: String.Encoding = .utf8, typeNumber: Int, errorCorrectLevel: QRErrorCorrectLevel) {
+    init?(text: String, encoding: String.Encoding = .utf8, typeNumber: Int, errorCorrectLevel: QRErrorCorrectLevel) {
         
-        guard let encoded = QR8bitByte(text, encoding: textEncoding) else {
+        guard let encoded = QR8bitByte(text, encoding: encoding) else {
             return nil
         }
         

--- a/Sources/QRCodeModel.swift
+++ b/Sources/QRCodeModel.swift
@@ -30,9 +30,9 @@ struct QRCodeModel {
     private let encodedText: QR8bitByte
     private var dataCache: [Int]
     
-    init?(text: String, typeNumber: Int, errorCorrectLevel: QRErrorCorrectLevel, textEncoding: String.Encoding = .utf8) {
+    init?(text: String, textEncoding: String.Encoding = .utf8, typeNumber: Int, errorCorrectLevel: QRErrorCorrectLevel) {
         
-        guard let encoded = QR8bitByte(text, encodingMode: textEncoding) else {
+        guard let encoded = QR8bitByte(text, encoding: textEncoding) else {
             return nil
         }
         


### PR DESCRIPTION
I've added an option to instantiate the QRCode object with a custom `String.Encoding`, because assuming UTF8 it's not the best solution for everyone.

I need to generate a QRcode with the bytes `<05000000 00005319 02062039 37179312 52279016>`

However trying to encode it as `.utf8` fails, the only way I could get this Data correctly on my reading was to use `.isoLatin1`.

This is still a workaround however, the perfect solution would be to accept raw `Data` directly.
Just like Apple's own implementation of the QRCodeGeneration filter receives `Data` because that is encoding agnostic.