### PR TITLE
fix: stride

### DIFF
--- a/Sources/QRCodeModel.swift
+++ b/Sources/QRCodeModel.swift
@@ -166,7 +166,8 @@ struct QRCodeModel {
         var bitIndex = 7
         var byteIndex = 0
 
-        for var col in stride(from: moduleCount - 1, to: 0, by: -2) {
+        var col: Int = moduleCount - 1
+        while (col > 0) {
             if col == 6 {
                 col -= 1
             }
@@ -196,6 +197,7 @@ struct QRCodeModel {
                     break
                 }
             }
+            col -= 2
         }
     }
 


### PR DESCRIPTION
The assignment to col is invalid in stride block, so the result will be different from [qrcode.js](https://github.com/davidshimjs/qrcodejs/blob/04f46c6a0708418cb7b96fc563eacae0fbf77674/qrcode.js#L100):

![](https://user-images.githubusercontent.com/10757132/93022777-8ab7b080-f61d-11ea-8887-b3d4999614f6.png)

